### PR TITLE
Update directory snapshot to have generic <PROJECT_DIR> file path

### DIFF
--- a/__tests__/__snapshots__/dist.ts.snap
+++ b/__tests__/__snapshots__/dist.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`dist works 1`] = `
 "
-/Users/Rob_LaFeve/Dev/caw-scripts/dist
+/<PROJECT_DIR>/dist
 ├── index.d.ts
 ├── index.js
 ├── index.js.map

--- a/__tests__/dist.ts
+++ b/__tests__/dist.ts
@@ -7,6 +7,8 @@ describe("dist", () => {
     spawn.sync("npm", ["run", "build"])
     process.chdir("./dist")
     const tree = spawn.sync("treee", ["-a", "-l 6"]).output.toString()
-    expect(trimEnds(tree)).toMatchSnapshot()
+    expect(
+      trimEnds(tree).replace(/(\/.*\/dist)/, "/<PROJECT_DIR>/dist"),
+    ).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
## Description

Updated the snapshot generation to replace the specific absolute project path with a generic `<PROJECT_DIR>` string. This ensures that snapshot tests will pass in any environment.

### 🖼 Demo

> Test images work nicely for this (table is optional)

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>

```
/Users/Rob_LaFeve/Dev/caw-scripts/dist
```

</td>
<td>

```
/<PROJECT_DIR>/dist
```

</td>
</tr>
</table>

### 📋 Acceptance Criteria

> Checked off by the PR **Assignee(s)**

- [ ] Snapshot tests work in any environment


### 👩‍🔬 Test Instructions

1. Pull down branch
1. Run `npm run test:unit`
1. Ensure tests pass

## 🔎 Reviewer Checklist

> Checked off by the PR **Reviewers**

### Required

> These always need to be checked

- [x] Merge destination is correct
- [x] Code is correct as understood and conforms to quality standards
- [x] Tests have been added where appropriate (unit, visual, end-to-end)
- [x] Acceptance Criteria have been met

### Additional

> Delete if unneeded

- [x] Code has been tested and confirmed locally

---

>### Roles & Responsibilities
>
>#### 👨‍💻 Assignee
>
>- Initiator of this PR (be sure to set in GitHub UI)
>- Addresses feedback and change requests
>- Merges PR once approved (usually deletes branch unless `develop` or `release`)
>
>#### 👩‍💻 Reviewer
>
>- Invited to review PR by **Assignee** (via GitHub UI)
>- Is expected to complete a review and address followup
